### PR TITLE
HEC-1192 LB changes for internal auth token

### DIFF
--- a/app/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConector.scala
+++ b/app/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConector.scala
@@ -40,12 +40,12 @@ class HECConnectorImpl @Inject() (http: HttpClient, config: Configuration)(impli
   private val servicesConfig           = new ServicesConfig(config)
   private val baseUrl: String          = servicesConfig.baseUrl("hec")
   private val matchTaxCheckUrl: String = s"$baseUrl/hec/match-tax-check"
+  val internalAuthToken: String        = config.get[String]("internal-auth.token")
 
   override def matchTaxCheck(taxCheckMatchRequest: HECTaxCheckMatchRequest)(implicit
     hc: HeaderCarrier
   ): EitherT[Future, Error, HttpResponse] = EitherT[Future, Error, HttpResponse] {
-    val internalAuthToken = config.get[String]("internal-auth.token")
-    val headers           = Seq(HeaderNames.authorisation -> internalAuthToken)
+    val headers = Seq(HeaderNames.authorisation -> internalAuthToken)
     http
       .POST[HECTaxCheckMatchRequest, HttpResponse](matchTaxCheckUrl, taxCheckMatchRequest, headers)
       .map(Right(_))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,3 +142,8 @@ contact-frontend.serviceId = "HEC-LB"
 
 maximum-verification-attempts = 3
 tax-check-verification-attempts-lock-hours = 2
+
+internal-auth {
+# use to authenticate the BE end point
+  token = "1234567890"
+}

--- a/test/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConnectorImplSpec.scala
@@ -16,18 +16,22 @@
 
 package uk.gov.hmrc.heclicensingbodyfrontend.connectors
 
+import cats.data.EitherT
 import com.typesafe.config.ConfigFactory
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
+import play.api.http.HeaderNames
+import play.api.test.Helpers._
+import uk.gov.hmrc.heclicensingbodyfrontend.models
 import uk.gov.hmrc.heclicensingbodyfrontend.models.licence.LicenceType
 import uk.gov.hmrc.heclicensingbodyfrontend.models.{DateOfBirth, HECTaxCheckCode, HECTaxCheckMatchRequest}
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory with HttpSupport with ConnectorSpec {
 
@@ -40,10 +44,15 @@ class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory wi
                                  |    host     = "$host"
                                  |    port     = $port
                                  |  }
+                                 |
+                                 | internal-auth {
+                                 |  token = "123456789"
+                                 | }
                                  |""".stripMargin)
   )
 
-  val connector                  = new HECConnectorImpl(mockHttp, new ServicesConfig(config))
+
+  val connector                  = new HECConnectorImpl(mockHttp, config)
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   val hecTaxCheckCode = HECTaxCheckCode("ABC DEF 123")
@@ -61,7 +70,7 @@ class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory wi
       val expectedUrl = s"$protocol://$host:$port/hec/match-tax-check"
 
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, taxCheckMatchRequest)(_),
+        mockPost(expectedUrl, Seq(HeaderNames.AUTHORIZATION -> "123456789"), taxCheckMatchRequest)(_),
         () => connector.matchTaxCheck(taxCheckMatchRequest)
       )
 

--- a/test/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/heclicensingbodyfrontend/connectors/HECConnectorImplSpec.scala
@@ -16,22 +16,18 @@
 
 package uk.gov.hmrc.heclicensingbodyfrontend.connectors
 
-import cats.data.EitherT
 import com.typesafe.config.ConfigFactory
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import play.api.http.HeaderNames
-import play.api.test.Helpers._
-import uk.gov.hmrc.heclicensingbodyfrontend.models
 import uk.gov.hmrc.heclicensingbodyfrontend.models.licence.LicenceType
 import uk.gov.hmrc.heclicensingbodyfrontend.models.{DateOfBirth, HECTaxCheckCode, HECTaxCheckMatchRequest}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory with HttpSupport with ConnectorSpec {
 
@@ -50,7 +46,6 @@ class HECConnectorImplSpec extends AnyWordSpec with Matchers with MockFactory wi
                                  | }
                                  |""".stripMargin)
   )
-
 
   val connector                  = new HECConnectorImpl(mockHttp, config)
   implicit val hc: HeaderCarrier = HeaderCarrier()


### PR DESCRIPTION
LB changes to pass internal auth to api calling match tax check end point.