### PR TITLE
DDCYLS-5625: Updating company registration number pattern

### DIFF
--- a/app/uk/gov/hmrc/heclicensingbodyfrontend/views/CompanyRegistrationNumber.scala.html
+++ b/app/uk/gov/hmrc/heclicensingbodyfrontend/views/CompanyRegistrationNumber.scala.html
@@ -41,7 +41,11 @@
 
 <h1 class="govuk-heading-l">@{messages(s"$key.title")}</h1>
 
-<p class="govuk-body">@{Html(messages("crn.link", appConfig.companiesHouseSearchUrl))}</p>
+<p class="govuk-body">@{messages(s"$key.info")}</p>
+
+<p class="govuk-body">
+    <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="@appConfig.companiesHouseSearchUrl">@messages("crn.linkMessage")</a>
+</p>
 
   @formWithCSRF(action = routes.CRNController.companyRegistrationNumberSubmit) {
     @govukInput(Input(
@@ -50,8 +54,8 @@
       value = form(key).value,
       label = Label(
         content = Text(messages("crn.label")),
-        isPageHeading = true,
-        classes = "govuk-label--xl",
+        isPageHeading = false,
+        classes = "govuk-label govuk-label--m",
       ),
       classes = "govuk-!-width-one-third",
       hint = Some(Hint(

--- a/conf/messages
+++ b/conf/messages
@@ -124,11 +124,11 @@ taxCheckExpired.viewAnother.heading = Confirm another tax check code
 taxCheckExpired.viewAnother.link = Confirm another applicant’s tax check code
 
 #CRN
-crn.title = What is the applicant’s company registration number?
+crn.title = Applicant’s company registration number
+crn.info = This is on the company’s Certificate of Incorporation and other documents from Companies House. It might be called ‘company number’ or ‘Companies House number’.
 crn.hint = It is 8 characters. For example, 01234567 or AC012345.
-crn.label = Enter your company registration number.
-crn.link = You can <a href="{0}"class="govuk-link" target="_blank">search Companies House for your company registration number (opens in new tab)</a>
-crn.linkMessage = search Companies House for your company registration number (opens in new tab)
+crn.label = What is the applicant’s company registration number?
+crn.linkMessage = Search Companies House for a company registration number (opens in new tab)
 crn.error.required = Enter the applicant’s company registration number
 crn.error.nonAlphanumericChars = The applicant’s company registration number must only include letters A to Z and numbers 0 to 9
 crn.error.crnInvalid = Enter the applicant’s company registration number in the correct format

--- a/test/uk/gov/hmrc/heclicensingbodyfrontend/controllers/CRNControllerSpec.scala
+++ b/test/uk/gov/hmrc/heclicensingbodyfrontend/controllers/CRNControllerSpec.scala
@@ -174,10 +174,12 @@ class CRNControllerSpec
 
           checkPageIsDisplayed(
             performAction(),
-            s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+            s"${messageFromMessageKey("crn.title")}",
             { doc =>
-              doc.select("#back").attr("href") shouldBe mockPreviousCall.url
-              doc.select(".govuk-hint").text() shouldBe messageFromMessageKey("crn.hint")
+              doc.select("p").text                should include(messageFromMessageKey("crn.info"))
+              doc.select("label[for='crn']").text should include(messageFromMessageKey("crn.label"))
+              doc.select("#back").attr("href")  shouldBe mockPreviousCall.url
+              doc.select(".govuk-hint").text()  shouldBe messageFromMessageKey("crn.hint")
 
               val button = doc.select("form")
               button.attr("action") shouldBe routes.CRNController.companyRegistrationNumberSubmit.url
@@ -208,10 +210,12 @@ class CRNControllerSpec
 
           checkPageIsDisplayed(
             performAction(),
-            s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+            s"${messageFromMessageKey("crn.title")}",
             { doc =>
-              doc.select("#back").attr("href") shouldBe mockPreviousCall.url
-              doc.select(".govuk-hint").text() shouldBe messageFromMessageKey("crn.hint")
+              doc.select("p").text                should include(messageFromMessageKey("crn.info"))
+              doc.select("label[for='crn']").text should include(messageFromMessageKey("crn.label"))
+              doc.select("#back").attr("href")  shouldBe mockPreviousCall.url
+              doc.select(".govuk-hint").text()  shouldBe messageFromMessageKey("crn.hint")
 
               val button = doc.select("form")
               button.attr("action") shouldBe routes.CRNController.companyRegistrationNumberSubmit.url
@@ -260,7 +264,7 @@ class CRNControllerSpec
 
           checkFormErrorIsDisplayed(
             performAction()(Language.English),
-            s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+            s"${messageFromMessageKey("crn.title")}",
             messageFromMessageKey("crn.error.required")
           )
         }
@@ -275,7 +279,7 @@ class CRNControllerSpec
 
           checkFormErrorIsDisplayed(
             performAction("crn" -> "1234567890")(Language.English),
-            s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+            s"${messageFromMessageKey("crn.title")}",
             messageFromMessageKey("crn.error.crnInvalid")
           )
         }
@@ -290,7 +294,7 @@ class CRNControllerSpec
 
           checkFormErrorIsDisplayed(
             performAction("crn" -> "12345")(Language.English),
-            s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+            s"${messageFromMessageKey("crn.title")}",
             messageFromMessageKey("crn.error.crnInvalid")
           )
         }
@@ -308,7 +312,7 @@ class CRNControllerSpec
 
               checkFormErrorIsDisplayed(
                 performAction("crn" -> crn.value)(Language.English),
-                s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+                s"${messageFromMessageKey("crn.title")}",
                 messageFromMessageKey("crn.error.nonAlphanumericChars")
               )
 
@@ -338,7 +342,7 @@ class CRNControllerSpec
 
               checkFormErrorIsDisplayed(
                 performAction("crn" -> crn.value)(Language.English),
-                s"${messageFromMessageKey("crn.title")} ${messageFromMessageKey("crn.label")}",
+                s"${messageFromMessageKey("crn.title")}",
                 messageFromMessageKey("crn.error.crnInvalid")
               )
 


### PR DESCRIPTION
Updating view pattern to a UTR design to fix label A11Y problem with original design. Setting page heading to false so only one H1 tag to prevent future A11Y issue as well.